### PR TITLE
Implement the overload-resolution TODO in `checker.rs`

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -155,7 +155,60 @@ impl<'gcx> TypeChecker<'gcx> {
                 self.check_binop(lhs_e, lhs, rhs_e, rhs, op, false)
             }
             hir::ExprKind::Call(callee, ref args, ref _opts) => {
-                let mut callee_ty = self.check_expr(callee);
+                let mut callee_ty = if let hir::ExprKind::Member(expr, ident) = &callee.kind {
+                    let expr_ty = self.check_expr(expr);
+                    if expr_ty.references_error() {
+                        expr_ty
+                    } else {
+                        let possible_members = self
+                            .gcx
+                            .members_of(expr_ty, self.source, self.contract)
+                            .iter()
+                            .filter(|m| m.name == ident.name)
+                            .collect::<SmallVec<[_; 4]>>();
+
+                        let ty = match possible_members[..] {
+                            [] => {
+                                let msg = format!(
+                                    "member `{ident}` not found on type `{}`",
+                                    expr_ty.display(self.gcx)
+                                );
+                                let err = self.dcx().err(msg).span(ident.span);
+                                self.gcx.mk_ty_err(err.emit())
+                            }
+                            [member] => member.ty,
+                            [..] => {
+                                let possible_members = possible_members
+                                    .into_iter()
+                                    .filter(|member| match member.ty.kind {
+                                        TyKind::FnPtr(f) => f.parameters.len() == args.len(),
+                                        TyKind::Event(param_tys, _)
+                                        | TyKind::Error(param_tys, _) => {
+                                            param_tys.len() == args.len()
+                                        }
+                                        _ => false,
+                                    })
+                                    .collect::<SmallVec<[_; 4]>>();
+                                match possible_members[..] {
+                                    [member] => member.ty,
+                                    [..] | [] => {
+                                        let msg = format!(
+                                            "member `{ident}` not unique on type `{}`",
+                                            expr_ty.display(self.gcx)
+                                        );
+                                        let err = self.dcx().err(msg).span(ident.span);
+                                        self.gcx.mk_ty_err(err.emit())
+                                    }
+                                }
+                            }
+                        };
+
+                        self.register_ty(callee, ty);
+                        ty
+                    }
+                } else {
+                    self.check_expr(callee)
+                };
 
                 // Get the function type for struct constructors, keeping struct_id for field names.
                 let struct_id = if let TyKind::Type(struct_ty) = callee_ty.kind


### PR DESCRIPTION
## Summary
Implement the overload-resolution TODO in `checker.rs`

## Design Rationale
Promoted from patch wk_1UdCfMezFkpN as a draft PR with best-effort verification evidence.
Source task: run_rs_BvHTnVildv:roadmap:typeck-overload-resolution
Session: rs_BvHTnVildv

## Validation
- cargo.build [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- cargo.nextest [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- cargo.uitest [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- cargo.clippy [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- cargo.fmt [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- solc_syntax_tests [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- solc_yul_tests [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- codspeed_check [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- Trace: https://pads.dev/research/rs_BvHTnVildv/trace
- Runtime: https://pads.dev/v1/runs/run_rs_BvHTnVildv/runtime
- Monitoring: https://pads.dev/research/rs_BvHTnVildv/monitoring
- Events: https://pads.dev/v1/runs/run_rs_BvHTnVildv/events
- Patch entries: wk_1UdCfMezFkpN
- Source tasks: run_rs_BvHTnVildv:roadmap:typeck-overload-resolution

## Risk
No known breaking-change risk; diff stays inside the declared blast radius.

## Follow-ups
- Review advisory benchmark deltas before merge.

---
Prepared by the pads.dev autonomous orchestrator. A human owns every decision.
- Live trace: https://pads.dev/research/rs_BvHTnVildv/trace