### PR TITLE
Preserve solc annotation line numbers in tools/tester

### DIFF
--- a/tools/tester/src/errors.rs
+++ b/tools/tester/src/errors.rs
@@ -71,7 +71,7 @@ impl Error {
                         _ => ErrorKind::Error,
                     };
                     let start = caps.get(2).map(|cap| cap.as_str().parse().unwrap()).unwrap_or(0);
-                    let line_num = file[..start].lines().count();
+                    let line_num = if start > 0 { file[..start].lines().count() } else { 0 };
                     let msg = caps.get(4).unwrap().as_str().trim().to_owned();
                     errors.push(Self {
                         line_num,


### PR DESCRIPTION
## Summary
Preserve solc annotation line numbers in tools/tester

## Design Rationale
Promoted from patch wk_y93gDdtVQBF0 as a draft PR with best-effort verification evidence.
Source task: run_rs_TqZPKVzLOR:roadmap:solar-tester-oracle-reporting-first-slice
Session: rs_TqZPKVzLOR

## Validation
- cargo.build [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- cargo.nextest [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- cargo.uitest [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- cargo.clippy [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- cargo.fmt [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- solc_syntax_tests [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- solc_yul_tests [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- codspeed_check [advisory] — Deferred for draft PR flow. Worker evidence and patch diff are published now; rerun this oracle before merge.
- Trace: https://pads.dev/research/rs_TqZPKVzLOR/trace
- Runtime: https://pads.dev/v1/runs/run_rs_TqZPKVzLOR/runtime
- Monitoring: https://pads.dev/research/rs_TqZPKVzLOR/monitoring
- Events: https://pads.dev/v1/runs/run_rs_TqZPKVzLOR/events
- Patch entries: wk_y93gDdtVQBF0
- Source tasks: run_rs_TqZPKVzLOR:roadmap:solar-tester-oracle-reporting-first-slice

## Risk
No known breaking-change risk; diff stays inside the declared blast radius.

## Follow-ups
- Review advisory benchmark deltas before merge.

---
Prepared by the pads.dev autonomous orchestrator. A human owns every decision.
- Live trace: https://pads.dev/research/rs_TqZPKVzLOR/trace