### PR TITLE
Add actionable skip and eligibility reporting to the Solidity solc runner

### DIFF
--- a/tools/tester/src/solc/solidity.rs
+++ b/tools/tester/src/solc/solidity.rs
@@ -6,51 +6,103 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+use std::sync::{Mutex, OnceLock};
+use std::collections::HashMap;
+
+/// Global accumulator for skip reasons and counts.
+static SKIP_REPORT: OnceLock<Mutex<HashMap<&'static str, usize>>> = OnceLock::new();
+
+fn skip_report() -> &'static Mutex<HashMap<&'static str, usize>> {
+    SKIP_REPORT.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Increment the counter for a skip reason.
+fn record_skip(reason: &'static str) {
+    let mut map = skip_report().lock().unwrap();
+    *map.entry(reason).or_insert(0) += 1;
+}
+
+/// Print a reviewer-readable summary of skipped vs attempted tests.
+pub fn print_skip_summary() {
+    let map = skip_report().lock().unwrap();
+    if map.is_empty() {
+        eprintln!("solc-solidity skip summary: no skips recorded");
+        return;
+    }
+    let total_skips: usize = map.values().sum();
+    eprintln!("solc-solidity skip summary: {} skipped total", total_skips);
+    let mut reasons: Vec<_> = map.iter().collect();
+    reasons.sort_by_key(|(reason, _)| *reason);
+    for (reason, count) in reasons {
+        eprintln!("  {:>4} x {}", count, reason);
+    }
+}
+
 pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
     let path_contains = path_contains_curry(path);
 
     if path_contains("/libyul/") {
-        return Err("actually a Yul test");
+        let reason = "actually a Yul test";
+        record_skip(reason);
+        return Err(reason);
     }
 
     if path_contains("/cmdlineTests/") {
-        return Err("CLI tests do not have the same format as everything else");
+        let reason = "CLI tests do not have the same format as everything else";
+        record_skip(reason);
+        return Err(reason);
     }
 
     if path_contains("/lsp/") {
-        return Err("LSP tests do not have the same format as everything else");
+        let reason = "LSP tests do not have the same format as everything else";
+        record_skip(reason);
+        return Err(reason);
     }
 
     if path_contains("/ASTJSON/") {
-        return Err("no JSON AST");
+        let reason = "no JSON AST";
+        record_skip(reason);
+        return Err(reason);
     }
 
     if path_contains("/functionDependencyGraphTests/") || path_contains("/experimental") {
-        return Err("solidity experimental is not implemented");
+        let reason = "solidity experimental is not implemented";
+        record_skip(reason);
+        return Err(reason);
     }
 
     // We don't parse licenses.
     if path_contains("/license/") {
-        return Err("licenses are not checked");
+        let reason = "licenses are not checked";
+        record_skip(reason);
+        return Err(reason);
     }
 
     if path_contains("natspec") {
-        return Err("natspec is not checked");
+        let reason = "natspec is not checked";
+        record_skip(reason);
+        return Err(reason);
     }
 
     if path_contains("_direction_override") {
-        return Err("Unicode direction override checks not implemented");
+        let reason = "Unicode direction override checks not implemented";
+        record_skip(reason);
+        return Err(reason);
     }
 
     if path_contains("wrong_compiler_") {
-        return Err("Solidity pragma version is not checked");
+        let reason = "Solidity pragma version is not checked";
+        record_skip(reason);
+        return Err(reason);
     }
 
     // Directories starting with `_` are not tests.
     if path_contains("/_")
         && !path.components().next_back().unwrap().as_os_str().to_str().unwrap().starts_with('_')
     {
-        return Err("supporting file");
+        let reason = "supporting file";
+        record_skip(reason);
+        return Err(reason);
     }
 
     let stem = path.file_stem().unwrap().to_str().unwrap();
@@ -106,7 +158,9 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         | "mapping_nonelementary_key_1"
         | "mapping_nonelementary_key_4"
     ) {
-        return Err("manually skipped");
+        let reason = "manually skipped";
+        record_skip(reason);
+        return Err(reason);
     };
 
     Ok(())


### PR DESCRIPTION
## Summary
Add actionable skip and eligibility reporting to the Solidity solc runner

## Design Rationale
Promoted from patch wk_XP1n98etVdWj as a draft PR with best-effort verification evidence.
Source task: run_rs_2NLCXAqkjT:roadmap:task-solidity-corpus-counts
Session: rs_2NLCXAqkjT

## Validation
- cargo.check [prerequisite] — Required before marking this draft ready; not satisfied by PR publication.
- cargo.build [prerequisite] — Required before marking this draft ready; not satisfied by PR publication.
- cargo.nextest [gate] — Required before marking this draft ready; not satisfied by PR publication.
- cargo.uitest [gate] — Required before marking this draft ready; not satisfied by PR publication.
- cargo.clippy [gate] — Required before marking this draft ready; not satisfied by PR publication.
- cargo.fmt [gate] — Required before marking this draft ready; not satisfied by PR publication.
- typos [prerequisite] — Required before marking this draft ready; not satisfied by PR publication.
- solc_syntax_parser [gate] — Required before marking this draft ready; not satisfied by PR publication.
- solc_yul_parser [gate] — Required before marking this draft ready; not satisfied by PR publication.
- solar_tester_unit [gate] — Required before marking this draft ready; not satisfied by PR publication.
- codspeed_check [advisory] — Deferred advisory oracle for draft PR flow.
- Trace: https://pads.dev/research/rs_2NLCXAqkjT/trace
- Runtime: https://pads.dev/v1/runs/run_rs_2NLCXAqkjT/runtime
- Monitoring: https://pads.dev/research/rs_2NLCXAqkjT/monitoring
- Events: https://pads.dev/v1/runs/run_rs_2NLCXAqkjT/events
- Patch entries: wk_XP1n98etVdWj
- Source tasks: run_rs_2NLCXAqkjT:roadmap:task-solidity-corpus-counts

## Risk
No known breaking-change risk; diff stays inside the declared blast radius.

## Follow-ups
- Review advisory benchmark deltas before merge.

---
Prepared by the pads.dev autonomous orchestrator. A human owns every decision.
- Live trace: https://pads.dev/research/rs_2NLCXAqkjT/trace