### PR TITLE
Add deterministic skip-reason summaries to the Yul solc runner

### DIFF
--- a/tools/tester/src/solc/yul.rs
+++ b/tools/tester/src/solc/yul.rs
@@ -1,5 +1,51 @@
 use crate::utils::path_contains_curry;
-use std::path::Path;
+use std::{collections::BTreeMap, path::Path};
+
+const SKIP_REASONS: &[(&str, &str)] = &[
+    ("blobbasefee_identifier_pre_cancun", "EVM version-aware parsing"),
+    ("blobhash_pre_cancun", "EVM version-aware parsing"),
+    ("clash_with_non_reserved_pure_yul_builtin", "EVM version-aware parsing"),
+    ("clash_with_reserved_pure_yul_builtin", "EVM version-aware parsing"),
+    ("clash_with_reserved_pure_yul_builtin_eof", "EVM version-aware parsing"),
+    ("clz", "EVM version-aware parsing"),
+    ("datacopy_shadowing", "Yul object syntax"),
+    ("dataoffset_shadowing", "Yul object syntax"),
+    ("datasize_shadowing", "Yul object syntax"),
+    ("eof_names_reserved_in_eof", "EVM version-aware parsing"),
+    ("extcall_function_in_eof", "EVM version-aware parsing"),
+    ("extdelegatecall_function_in_eof", "EVM version-aware parsing"),
+    ("extstaticcall_function_in_eof", "EVM version-aware parsing"),
+    ("for_statement_nested_continue", "post-parse validation"),
+    ("linkersymbol_invalid_redefine_builtin", "post-parse validation"),
+    ("linkersymbol_shadowing", "Yul object syntax"),
+    ("loadimmutable_shadowing", "Yul object syntax"),
+    ("mcopy_as_identifier_pre_cancun", "EVM version-aware parsing"),
+    ("mcopy_pre_cancun", "EVM version-aware parsing"),
+    ("number_literal_2", "post-parse validation"),
+    ("number_literal_3", "post-parse validation"),
+    ("number_literal_4", "post-parse validation"),
+    ("number_literals_2", "post-parse validation"),
+    ("number_literals_3", "post-parse validation"),
+    ("number_literals_4", "post-parse validation"),
+    ("pc_disallowed", "post-parse validation"),
+    ("setimmutable_shadowing", "Yul object syntax"),
+    ("tstore_tload_as_identifiers_pre_cancun", "EVM version-aware parsing"),
+    ("unicode_comment_direction_override", "unicode comment validation"),
+];
+
+pub(crate) fn skip_summary() -> BTreeMap<&'static str, usize> {
+    let mut summary = BTreeMap::new();
+    for &(_, reason) in SKIP_REASONS {
+        *summary.entry(reason).or_default() += 1;
+    }
+
+    summary.insert("not a Yul file", 0);
+    summary.insert("not actually valid identifiers", 3);
+    summary.insert("not implemented in the parser", 2);
+    summary.insert("recursion stack overflow", 1);
+    summary.insert("verbatim Yul builtin is not implemented", 1);
+    summary
+}
 
 pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
     let path_contains = path_contains_curry(path);
@@ -32,44 +78,8 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
     }
 
     let stem = path.file_stem().unwrap().to_str().unwrap();
-    #[rustfmt::skip]
-    if matches!(
-        stem,
-        // TODO: Why should this fail?
-        | "unicode_comment_direction_override"
-        // TODO: Implement after parsing.
-        | "number_literals_2"
-        | "number_literals_3"
-        | "number_literals_4"
-        | "number_literal_2"
-        | "number_literal_3"
-        | "number_literal_4"
-        | "pc_disallowed"
-        | "for_statement_nested_continue"
-        | "linkersymbol_invalid_redefine_builtin"
-        // TODO: Implemented with Yul object syntax.
-        | "datacopy_shadowing"
-        | "dataoffset_shadowing"
-        | "datasize_shadowing"
-        | "linkersymbol_shadowing"
-        | "loadimmutable_shadowing"
-        | "setimmutable_shadowing"
-        // TODO: EVM version-aware parsing.
-        | "blobbasefee_identifier_pre_cancun"
-        | "blobhash_pre_cancun"
-        | "mcopy_as_identifier_pre_cancun"
-        | "mcopy_pre_cancun"
-        | "tstore_tload_as_identifiers_pre_cancun"
-        | "eof_names_reserved_in_eof"
-        | "extcall_function_in_eof"
-        | "extdelegatecall_function_in_eof"
-        | "extstaticcall_function_in_eof"
-        | "clash_with_non_reserved_pure_yul_builtin"
-        | "clash_with_reserved_pure_yul_builtin_eof"
-        | "clash_with_reserved_pure_yul_builtin"
-        | "clz"
-    ) {
-        return Err("manually skipped");
+    if let Some(&(_, reason)) = SKIP_REASONS.iter().find(|&&(skipped, _)| skipped == stem) {
+        return Err(reason);
     };
 
     Ok(())


### PR DESCRIPTION
## Summary
Add deterministic skip-reason summaries to the Yul solc runner

## Design Rationale
Opened as a draft PR after draft-gate checks: the patch applied cleanly and passed local review.
Required ready gates remain blockers until they pass.

## Validation
- cargo.check [prerequisite] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.build [prerequisite] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.nextest [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.uitest [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.clippy [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.fmt [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- typos [prerequisite] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- solc_syntax_parser [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- solc_yul_parser [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- solar_tester_unit [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- codspeed_check [advisory] — Deferred advisory oracle for draft PR flow.
- Runtime evidence is available in Pads for maintainers with access.

## Risk
No known breaking-change risk; diff stays inside the declared blast radius.

## Follow-ups
- Review advisory benchmark deltas before merge.

---
Prepared by the pads.dev autonomous orchestrator. A human owns every decision.
- Live trace: https://pads.dev/research/rs_MY0DUUWW27/trace