### PR TITLE
Made solc corpus routing explicit with a typed SolcCorpusMode helper, routed file filtering through it, and added an in-file regression test for Solidity/Yul skip dispatch.

### DIFF
--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -179,10 +179,9 @@ fn file_filter(path: &Path, config: &ui_test::Config, cfg: MyConfig<'_>) -> Opti
     if !ui_test::default_any_file_filter(path, config) {
         return Some(false);
     }
-    let skip = match cfg.mode {
-        Mode::Ui => false,
-        Mode::SolcSolidity => solc::solidity::should_skip(path).is_err(),
-        Mode::SolcYul => solc::yul::should_skip(path).is_err(),
+    let skip = match cfg.mode.solc_corpus_mode() {
+        Some(mode) => mode.should_skip(path).is_err(),
+        None => false,
     };
     Some(!skip)
 }
@@ -267,6 +266,14 @@ impl Mode {
 
     fn allows_yul(self) -> bool {
         !matches!(self, Self::SolcSolidity)
+    }
+
+    fn solc_corpus_mode(self) -> Option<solc::solidity::SolcCorpusMode> {
+        match self {
+            Self::Ui => None,
+            Self::SolcSolidity => Some(solc::solidity::SolcCorpusMode::Solidity),
+            Self::SolcYul => Some(solc::solidity::SolcCorpusMode::Yul),
+        }
     }
 }
 

--- a/tools/tester/src/solc/solidity.rs
+++ b/tools/tester/src/solc/solidity.rs
@@ -6,6 +6,21 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SolcCorpusMode {
+    Solidity,
+    Yul,
+}
+
+impl SolcCorpusMode {
+    pub(crate) fn should_skip(self, path: &Path) -> Result<(), &'static str> {
+        match self {
+            Self::Solidity => should_skip(path),
+            Self::Yul => super::yul::should_skip(path),
+        }
+    }
+}
+
 pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
     let path_contains = path_contains_curry(path);
 
@@ -208,4 +223,18 @@ fn source_delim(line: &str) -> Option<&str> {
 
 fn external_source_delim(line: &str) -> Option<&str> {
     line.strip_prefix("==== ExternalSource:").and_then(|s| s.strip_suffix("====")).map(str::trim)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn solc_corpus_mode_routes_skip_rules() {
+        let yul_test = Path::new("/solidity/test/libyul/parser/simple.yul");
+        let solidity_test = Path::new("/solidity/test/libyul/not_yul.sol");
+
+        assert_eq!(SolcCorpusMode::Solidity.should_skip(yul_test), Err("actually a Yul test"));
+        assert_eq!(SolcCorpusMode::Yul.should_skip(solidity_test), Err("not a Yul file"));
+    }
 }


### PR DESCRIPTION
## Summary\nMade solc corpus routing explicit with a typed SolcCorpusMode helper, routed file filtering through it, and added an in-file regression test for Solidity/Yul skip dispatch.\n\n## Verification\n- cargo fmt --all --check: exit 0\n- cargo check -p solar-tester: exit 0\n- cargo test -p solar-tester solc_corpus_mode_routes_skip_rules: exit 0\n\n## Notes\nDirect smoke harness task: 30ea4162bff1