### PR TITLE
Mirror summary accounting for the Yul solc tester path

### DIFF
--- a/tools/tester/src/solc/yul.rs
+++ b/tools/tester/src/solc/yul.rs
@@ -1,15 +1,43 @@
 use crate::utils::path_contains_curry;
 use std::path::Path;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SkipCategory {
+    UnsupportedSolarBehavior,
+    NonParserResponsibility,
+    SolcAcceptedInvalidSyntax,
+    NonYulInput,
+    ManualInvestigation,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SkipReason {
+    pub(crate) category: SkipCategory,
+    pub(crate) reason: &'static str,
+}
+
+impl SkipReason {
+    const fn new(category: SkipCategory, reason: &'static str) -> Self {
+        Self { category, reason }
+    }
+}
+
 pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
+    should_skip_reason(path).map_err(|reason| reason.reason)
+}
+
+pub(crate) fn should_skip_reason(path: &Path) -> Result<(), SkipReason> {
     let path_contains = path_contains_curry(path);
 
     if path_contains("/recursion_depth.yul") {
-        return Err("recursion stack overflow");
+        return Err(SkipReason::new(SkipCategory::UnsupportedSolarBehavior, "recursion stack overflow"));
     }
 
     if path_contains("/verbatim") {
-        return Err("verbatim Yul builtin is not implemented");
+        return Err(SkipReason::new(
+            SkipCategory::UnsupportedSolarBehavior,
+            "verbatim Yul builtin is not implemented",
+        ));
     }
 
     if path_contains("/period_in_identifier")
@@ -19,16 +47,22 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         // Why does Solc parse periods as part of Yul identifiers?
         // `yul-identifier` is the same as `solidity-identifier`, which disallows periods:
         // https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityLexer.YulIdentifier
-        return Err("not actually valid identifiers");
+        return Err(SkipReason::new(
+            SkipCategory::SolcAcceptedInvalidSyntax,
+            "not actually valid identifiers",
+        ));
     }
 
     if path_contains("objects/conflict_") || path_contains("objects/code.yul") {
         // Not the parser's job to check conflicting names.
-        return Err("not implemented in the parser");
+        return Err(SkipReason::new(
+            SkipCategory::NonParserResponsibility,
+            "not implemented in the parser",
+        ));
     }
 
     if path_contains(".sol") {
-        return Err("not a Yul file");
+        return Err(SkipReason::new(SkipCategory::NonYulInput, "not a Yul file"));
     }
 
     let stem = path.file_stem().unwrap().to_str().unwrap();
@@ -69,8 +103,61 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         | "clash_with_reserved_pure_yul_builtin"
         | "clz"
     ) {
-        return Err("manually skipped");
+        return Err(SkipReason::new(SkipCategory::ManualInvestigation, "manually skipped"));
     };
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_skip, should_skip_reason, SkipCategory, SkipReason};
+    use std::path::Path;
+
+    fn skip_reason(path: &str) -> SkipReason {
+        should_skip_reason(Path::new(path)).unwrap_err()
+    }
+
+    #[test]
+    fn yul_skip_accounting_distinguishes_coverage_buckets() {
+        assert_eq!(
+            skip_reason("test/libyul/yulOptimizerTests/recursion_depth.yul"),
+            SkipReason::new(SkipCategory::UnsupportedSolarBehavior, "recursion stack overflow")
+        );
+        assert_eq!(
+            skip_reason("test/libyul/yulParserTests/verbatim.yul"),
+            SkipReason::new(
+                SkipCategory::UnsupportedSolarBehavior,
+                "verbatim Yul builtin is not implemented"
+            )
+        );
+        assert_eq!(
+            skip_reason("test/libyul/yulParserTests/period_in_identifier/input.yul"),
+            SkipReason::new(
+                SkipCategory::SolcAcceptedInvalidSyntax,
+                "not actually valid identifiers"
+            )
+        );
+        assert_eq!(
+            skip_reason("test/libyul/yulParserTests/objects/conflict_code.yul"),
+            SkipReason::new(SkipCategory::NonParserResponsibility, "not implemented in the parser")
+        );
+        assert_eq!(
+            skip_reason("test/libyul/SolidityFile.sol"),
+            SkipReason::new(SkipCategory::NonYulInput, "not a Yul file")
+        );
+        assert_eq!(
+            skip_reason("test/libyul/yulParserTests/number_literals_2.yul"),
+            SkipReason::new(SkipCategory::ManualInvestigation, "manually skipped")
+        );
+    }
+
+    #[test]
+    fn legacy_skip_api_still_returns_reason_strings() {
+        assert_eq!(
+            should_skip(Path::new("test/libyul/yulParserTests/number_literals_2.yul")),
+            Err("manually skipped")
+        );
+        assert_eq!(should_skip(Path::new("test/libyul/yulParserTests/simple.yul")), Ok(()));
+    }
 }


### PR DESCRIPTION
## Summary
Mirror summary accounting for the Yul solc tester path

## Design Rationale
Opened as a draft PR after draft-gate checks: the patch applied cleanly and passed local review.
Required ready gates remain blockers until they pass.

## Validation
- cargo.check [prerequisite] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.build [prerequisite] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.nextest [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.uitest [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.clippy [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.fmt [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- typos [prerequisite] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- solc_syntax_parser [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- solc_yul_parser [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- solar_tester_unit [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- codspeed_check [advisory] — Deferred advisory oracle for draft PR flow.
- Runtime evidence is available in Pads for maintainers with access.

## Risk
No known breaking-change risk; diff stays inside the declared blast radius.

## Follow-ups
- Review advisory benchmark deltas before merge.

---
Prepared by the pads.dev autonomous orchestrator. A human owns every decision.
- Live trace: https://pads.dev/research/rs_RmovYeveBp/trace