### PR TITLE
Expose distinct `-Ztypeck` counts in the solc Solidity tester

### DIFF
--- a/tools/tester/src/solc/solidity.rs
+++ b/tools/tester/src/solc/solidity.rs
@@ -55,7 +55,7 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
 
     let stem = path.file_stem().unwrap().to_str().unwrap();
     #[rustfmt::skip]
-    if matches!(
+    let skip_reason = if matches!(
         stem,
         // Exponent is too large, but apparently it's fine in Solc because the result is 0 or it gets evaluated at compile time.
         | "rational_number_exp_limit_fine"
@@ -94,6 +94,24 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         // Validation is in solar's AST stage (https://github.com/paradigmxyz/solar/pull/120).
         | "empty_enum"
 
+    ) {
+        Some("manually skipped")
+    } else if needs_typeck(stem) {
+        Some("requires -Ztypeck")
+    } else {
+        None
+    };
+
+    if let Some(reason) = skip_reason {
+        return Err(reason);
+    }
+
+    Ok(())
+}
+
+fn needs_typeck(stem: &str) -> bool {
+    matches!(
+        stem,
         // Data locations are checked after parsing.
         | "stopAfterParsingError"
         | "state_variable_storage_named_transient"
@@ -105,11 +123,7 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         // Mapping key types are checked in sema.
         | "mapping_nonelementary_key_1"
         | "mapping_nonelementary_key_4"
-    ) {
-        return Err("manually skipped");
-    };
-
-    Ok(())
+    )
 }
 
 /// Handles `====` delimiters in a solc test file, and creates temporary files as necessary.


### PR DESCRIPTION
## Summary
Expose distinct `-Ztypeck` counts in the solc Solidity tester

## Design Rationale
Opened as a draft PR after draft-gate checks: the patch applied cleanly and passed local review.
Required ready gates remain blockers until they pass.

## Validation
- cargo.check [prerequisite] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.build [prerequisite] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.nextest [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.uitest [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.clippy [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- cargo.fmt [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- typos [prerequisite] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- solc_syntax_parser [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- solc_yul_parser [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- solar_tester_unit [gate] — Ready gate deferred; draft publication only proves the patch applied cleanly and passed local review.
- codspeed_check [advisory] — Deferred advisory oracle for draft PR flow.
- Runtime evidence is available in Pads for maintainers with access.

## Risk
No known breaking-change risk; diff stays inside the declared blast radius.

## Follow-ups
- Review advisory benchmark deltas before merge.

---
Prepared by the pads.dev autonomous orchestrator. A human owns every decision.
- Live trace: https://pads.dev/research/rs_YwNRKnDKNc/trace