### PR TITLE
Fix or narrow the first measured -Ztypeck corpus failure

### DIFF
--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -86,8 +86,10 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
             args: {
                 let mut args =
                     vec!["-j1", "--error-format=rustc-json", "-Zui-testing", "-Zparse-yul"];
-                if mode.is_solc() {
-                    args.push("--stop-after=parsing");
+                match mode {
+                    Mode::SolcSolidity => args.push("-Ztypeck"),
+                    Mode::SolcYul => args.push("--stop-after=parsing"),
+                    Mode::Ui => {}
                 }
                 args.into_iter().map(Into::into).collect()
             },
@@ -213,8 +215,10 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
     let expected_errors = errors::Error::load_solc(src);
     let expected_error = expected_errors.iter().find(|e| e.is_error());
     let code = if let Some(expected_error) = expected_error {
-        // Expect failure only for parser errors, otherwise ignore exit code.
-        if expected_error.solc_kind.is_some_and(|kind| kind.is_parser_error()) {
+        // Expect failure for diagnostics in the compiler phases this corpus mode runs.
+        if expected_error.solc_kind.is_some_and(|kind| {
+            kind.is_parser_error() || cfg.mode.checks_solidity_typeck() && kind.is_typeck_error()
+        }) {
             Some(1)
         } else {
             None
@@ -267,6 +271,10 @@ impl Mode {
 
     fn allows_yul(self) -> bool {
         !matches!(self, Self::SolcSolidity)
+    }
+
+    fn checks_solidity_typeck(self) -> bool {
+        matches!(self, Self::SolcSolidity)
     }
 }
 

--- a/tools/tester/src/solc/mod.rs
+++ b/tools/tester/src/solc/mod.rs
@@ -82,6 +82,10 @@ impl SolcErrorKind {
         matches!(self, Self::DocstringParsingError | Self::ParserError)
     }
 
+    pub fn is_typeck_error(&self) -> bool {
+        matches!(self, Self::DeclarationError | Self::TypeError)
+    }
+
     pub(crate) fn is_error(&self) -> bool {
         !matches!(self, Self::Info | Self::Warning)
     }


### PR DESCRIPTION
## Summary
2 files changed (+16 -4). Touches `tools/tester/src/lib.rs`, `tools/tester/src/solc/mod.rs`. Diff size: +16/-4. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo +nightly fmt --all --check exit 0 advisory. Risk flags: Patch likely exposes many corpus TypeError/DeclarationError failures rather than narrowing to one fixture.; No focused regression test was added.; Target oracle and cargo check were not run.. Advisory oracles deferred to CI/reviewer follow-up: `lint`, `test`, `verification:cargo +nightly fmt --all --check`, `verification:typos --format brief`, `verification:cargo check --workspace`, `verification:cargo build --workspace`, `verification:cargo clippy --workspace --all-t`, `verification:cargo nextest run --workspace`, `verification:cargo test --doc --workspace`, `verification:cargo uitest`, `verification:TESTER_MODE=solc-solidity cargo `, `verification:TESTER_MODE=solc-yul cargo nexte`, `verification:forge config --json && forge rem`, `verification:cargo test -p solar-mir`, `verification:cargo codspeed build && cargo co`, `verification:cargo bench -p solar-bench --ben`, `verification:test -d research || true`. Run evidence: run_rs_Nv4IgSTGrw on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- lint [advisory/deferred] `cargo clippy --workspace --all-targets` - Deferred advisory oracle for sandboxless draft PR publication.
- test [advisory/deferred] `cargo test` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo +nightly fmt --all --check [advisory/deferred] `cargo +nightly fmt --all --check` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:typos --format brief [advisory/deferred] `typos --format brief` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo check --workspace [advisory/deferred] `cargo check --workspace` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo build --workspace [advisory/deferred] `cargo build --workspace` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo clippy --workspace --all-t [advisory/deferred] `cargo clippy --workspace --all-targets -- -D warnings` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo nextest run --workspace [advisory/deferred] `cargo nextest run --workspace` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo test --doc --workspace [advisory/deferred] `cargo test --doc --workspace` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo uitest [advisory/deferred] `cargo uitest` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:TESTER_MODE=solc-solidity cargo  [advisory/deferred] `TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:TESTER_MODE=solc-yul cargo nexte [advisory/deferred] `TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:forge config --json && forge rem [advisory/deferred] `forge config --json && forge remappings` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo test -p solar-mir [advisory/deferred] `cargo test -p solar-mir` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo codspeed build && cargo co [advisory/deferred] `cargo codspeed build && cargo codspeed run` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo bench -p solar-bench --ben [advisory/deferred] `cargo bench -p solar-bench --bench iai` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:test -d research || true [advisory/deferred] `test -d research || true` - Deferred advisory oracle for sandboxless draft PR publication.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 2 files changed
- +16 / -4