### PR TITLE
Route solc-solidity-typeck mode

### DIFF
--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -183,9 +183,7 @@ fn file_filter(path: &Path, config: &ui_test::Config, cfg: MyConfig<'_>) -> Opti
     }
     let skip = match cfg.mode {
         Mode::Ui => false,
-        Mode::SolcSolidity | Mode::SolcSolidityTypeck => {
-            solc::solidity::should_skip(path).is_err()
-        }
+        Mode::SolcSolidity | Mode::SolcSolidityTypeck => solc::solidity::should_skip(path).is_err(),
         Mode::SolcYul => solc::yul::should_skip(path).is_err(),
     };
     Some(!skip)

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -66,7 +66,7 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
 
     let path = match mode {
         Mode::Ui => "tests/ui/",
-        Mode::SolcSolidity => "testdata/solidity/test/",
+        Mode::SolcSolidity | Mode::SolcSolidityTypeck => "testdata/solidity/test/",
         Mode::SolcYul => "testdata/solidity/test/libyul/",
     };
     let tests_root = root.join(path);
@@ -86,7 +86,9 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
             args: {
                 let mut args =
                     vec!["-j1", "--error-format=rustc-json", "-Zui-testing", "-Zparse-yul"];
-                if mode.is_solc() {
+                if mode.is_solc_solidity_typeck() {
+                    args.push("-Ztypeck");
+                } else if mode.is_solc() {
                     args.push("--stop-after=parsing");
                 }
                 args.into_iter().map(Into::into).collect()
@@ -181,7 +183,9 @@ fn file_filter(path: &Path, config: &ui_test::Config, cfg: MyConfig<'_>) -> Opti
     }
     let skip = match cfg.mode {
         Mode::Ui => false,
-        Mode::SolcSolidity => solc::solidity::should_skip(path).is_err(),
+        Mode::SolcSolidity | Mode::SolcSolidityTypeck => {
+            solc::solidity::should_skip(path).is_err()
+        }
         Mode::SolcYul => solc::yul::should_skip(path).is_err(),
     };
     Some(!skip)
@@ -214,7 +218,9 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
     let expected_error = expected_errors.iter().find(|e| e.is_error());
     let code = if let Some(expected_error) = expected_error {
         // Expect failure only for parser errors, otherwise ignore exit code.
-        if expected_error.solc_kind.is_some_and(|kind| kind.is_parser_error()) {
+        if cfg.mode.is_solc_solidity_typeck()
+            || expected_error.solc_kind.is_some_and(|kind| kind.is_parser_error())
+        {
             Some(1)
         } else {
             None
@@ -224,7 +230,7 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
     };
     config.comment_defaults.base().exit_status = code.map(Spanned::dummy).into();
 
-    if matches!(cfg.mode, Mode::SolcSolidity) {
+    if matches!(cfg.mode, Mode::SolcSolidity | Mode::SolcSolidityTypeck) {
         let flags = &mut config.comment_defaults.base().compile_flags;
         let has_delimiters = solc::solidity::handle_delimiters(src, path, cfg.tmp_dir, |arg| {
             flags.push(arg.into_string().unwrap())
@@ -240,6 +246,7 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
 enum Mode {
     Ui,
     SolcSolidity,
+    SolcSolidityTypeck,
     SolcYul,
 }
 
@@ -248,6 +255,7 @@ impl Mode {
         Some(match s {
             "ui" => Self::Ui,
             "solc-solidity" => Self::SolcSolidity,
+            "solc-solidity-typeck" => Self::SolcSolidityTypeck,
             "solc-yul" => Self::SolcYul,
             _ => return None,
         })
@@ -257,12 +265,17 @@ impl Mode {
         match self {
             Self::Ui => "ui",
             Self::SolcSolidity => "solc-solidity",
+            Self::SolcSolidityTypeck => "solc-solidity-typeck",
             Self::SolcYul => "solc-yul",
         }
     }
 
     fn is_solc(self) -> bool {
-        matches!(self, Self::SolcSolidity | Self::SolcYul)
+        matches!(self, Self::SolcSolidity | Self::SolcSolidityTypeck | Self::SolcYul)
+    }
+
+    fn is_solc_solidity_typeck(self) -> bool {
+        matches!(self, Self::SolcSolidityTypeck)
     }
 
     fn allows_yul(self) -> bool {


### PR DESCRIPTION
## Summary
1 files changed (+19 -6). Touches `tools/tester/src/lib.rs`. Diff size: +19/-6. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo check -p solar-tester exit 0 required; TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests --no-fail-fast exit 0 required; TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests --no-fail-fast exit 0 required. Risk flags: Full typeck corpus command currently exits 100 because Solar typeck reports real corpus failures, as intended by non-ignored failures.; Default mode list remains UI + existing solc modes only to avoid making all-tests fail on current typeck corpus gaps.. Advisory oracles deferred to CI/reviewer follow-up: `lint`, `test`, `verification:cargo +nightly fmt --all --check`, `verification:typos --format brief`, `verification:cargo check --workspace`, `verification:cargo build --workspace`, `verification:cargo clippy --workspace --all-t`, `verification:cargo nextest run --workspace`, `verification:cargo test --doc --workspace`, `verification:cargo uitest`, `verification:TESTER_MODE=solc-solidity cargo `, `verification:TESTER_MODE=solc-yul cargo nexte`, `verification:forge config --json && forge rem`, `verification:cargo test -p solar-mir`, `verification:cargo codspeed build && cargo co`, `verification:cargo bench -p solar-bench --ben`, `verification:test -d research || true`. Run evidence: run_rs_7bSpFQvbMY on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- lint [advisory/deferred] `cargo clippy --workspace --all-targets` - Deferred advisory oracle for sandboxless draft PR publication.
- test [advisory/deferred] `cargo test` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo +nightly fmt --all --check [advisory/deferred] `cargo +nightly fmt --all --check` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:typos --format brief [advisory/deferred] `typos --format brief` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo check --workspace [advisory/deferred] `cargo check --workspace` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo build --workspace [advisory/deferred] `cargo build --workspace` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo clippy --workspace --all-t [advisory/deferred] `cargo clippy --workspace --all-targets -- -D warnings` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo nextest run --workspace [advisory/deferred] `cargo nextest run --workspace` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo test --doc --workspace [advisory/deferred] `cargo test --doc --workspace` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo uitest [advisory/deferred] `cargo uitest` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:TESTER_MODE=solc-solidity cargo  [advisory/deferred] `TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:TESTER_MODE=solc-yul cargo nexte [advisory/deferred] `TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:forge config --json && forge rem [advisory/deferred] `forge config --json && forge remappings` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo test -p solar-mir [advisory/deferred] `cargo test -p solar-mir` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo codspeed build && cargo co [advisory/deferred] `cargo codspeed build && cargo codspeed run` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:cargo bench -p solar-bench --ben [advisory/deferred] `cargo bench -p solar-bench --bench iai` - Deferred advisory oracle for sandboxless draft PR publication.
- verification:test -d research || true [advisory/deferred] `test -d research || true` - Deferred advisory oracle for sandboxless draft PR publication.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 1 files changed
- +19 / -6