### PR TITLE
Port one upstream TypeError fix

### DIFF
--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -356,9 +356,9 @@ impl<'gcx> Gcx<'gcx> {
         self.mk_ty_iter(ids.iter().map(|&id| self.type_of_item(id.into())))
     }
 
-    pub fn mk_ty_string_literal(self, s: &[u8]) -> Ty<'gcx> {
+    pub fn mk_ty_string_literal(self, is_string: bool, s: &[u8]) -> Ty<'gcx> {
         self.mk_ty(TyKind::StringLiteral(
-            std::str::from_utf8(s).is_ok(),
+            is_string,
             TypeSize::new_int_bits(s.len().min(32) as u16 * 8),
         ))
     }
@@ -655,7 +655,10 @@ impl<'gcx> Gcx<'gcx> {
     /// Returns the type of the given literal.
     pub fn type_of_lit(self, lit: &'gcx hir::Lit<'gcx>) -> Ty<'gcx> {
         match &lit.kind {
-            solar_ast::LitKind::Str(_, s, _) => self.mk_ty_string_literal(s.as_byte_str()),
+            solar_ast::LitKind::Str(kind, s, _) => self.mk_ty_string_literal(
+                matches!(kind, solar_ast::StrKind::Str | solar_ast::StrKind::Unicode),
+                s.as_byte_str(),
+            ),
             solar_ast::LitKind::Number(int) => {
                 let compatible_fixed_bytes = compatible_fixed_bytes_type(lit);
                 self.mk_ty_int_literal_with_fixed_bytes(

--- a/tests/ui/typeck/literal_bytes_implicit_conversion.stderr
+++ b/tests/ui/typeck/literal_bytes_implicit_conversion.stderr
@@ -8,7 +8,7 @@ error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/literal_bytes_implicit_conversion.sol:LL:CC
    │
 LL │         bytes2 invalid_h2 = hex"123456";
-   ╰╴                            ━━━━━━━━━━━ literal `utf8_string_literal[3]` is larger than the type `bytes2`
+   ╰╴                            ━━━━━━━━━━━ literal `bytes_string_literal[3]` is larger than the type `bytes2`
 
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/literal_bytes_implicit_conversion.sol:LL:CC


### PR DESCRIPTION
## Summary
2 files changed (+7 -4). Touches `crates/sema/src/ty/mod.rs`, `tests/ui/typeck/literal_bytes_implicit_conversion.stderr`. Diff size: +7/-4. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo check -p solar-sema -p solar-compiler exit 0 required; cargo uitest tests/ui/typeck/literal_bytes_implicit_conversion.sol exit 0 required; cargo +nightly fmt --all --check exit 1 blocked. Risk flags: Full cargo uitest and clippy were not run; targeted UI and cargo check passed.; cargo +nightly fmt --all --check blocked by rustup TLS handshake while syncing nightly.. Advisory oracles deferred to CI/reviewer follow-up (17 total): `lint`, `test`, `verification:cargo +nightly fmt --all --check`, .... Run evidence: run_rs_saZmR6RvJw on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- 17 advisory oracles deferred to CI; see Solar's required checks before marking the draft ready.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 2 files changed
- +7 / -4