### PR TITLE
Wire `solc-solidity-typeck` mode

### DIFF
--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -44,7 +44,7 @@ pub fn run_tests(cmd: &'static Path) -> Result<()> {
     let tmp_dir = &*Box::leak(tmp_dir.path().to_path_buf().into_boxed_path());
     for &mode in modes {
         let cfg = MyConfig::<'static> { mode, tmp_dir };
-        let config = config(cmd, &args, mode);
+        let config = config(cmd, &args, mode)?;
 
         let text_emitter: Box<dyn ui_test::status_emitter::StatusEmitter> = args.format.into();
         let gha_emitter = ui_test::status_emitter::Gha { name: mode.to_string(), group: true };
@@ -61,20 +61,21 @@ pub fn run_tests(cmd: &'static Path) -> Result<()> {
     Ok(())
 }
 
-fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Config {
+fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> Result<ui_test::Config> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap().parent().unwrap();
 
     let path = match mode {
         Mode::Ui => "tests/ui/",
-        Mode::SolcSolidity => "testdata/solidity/test/",
+        Mode::SolcSolidity | Mode::SolcSolidityTypeck => "testdata/solidity/test/",
         Mode::SolcYul => "testdata/solidity/test/libyul/",
     };
     let tests_root = root.join(path);
-    assert!(
-        tests_root.exists(),
-        "tests root directory does not exist: {path};\n\
-         you may need to initialize submodules: `git submodule update --init --checkout`"
-    );
+    if !tests_root.exists() {
+        return Err(eyre!(
+            "tests root directory does not exist: {path};\n\
+             you may need to initialize submodules: `git submodule update --init --checkout`"
+        ));
+    }
 
     let mut config = ui_test::Config {
         // `host` and `target` are used for `//@ignore-...` comments.
@@ -86,8 +87,10 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
             args: {
                 let mut args =
                     vec!["-j1", "--error-format=rustc-json", "-Zui-testing", "-Zparse-yul"];
-                if mode.is_solc() {
-                    args.push("--stop-after=parsing");
+                match mode {
+                    Mode::SolcSolidity | Mode::SolcYul => args.push("--stop-after=parsing"),
+                    Mode::SolcSolidityTypeck => args.push("-Ztypeck"),
+                    Mode::Ui => {}
                 }
                 args.into_iter().map(Into::into).collect()
             },
@@ -161,7 +164,7 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
         config.comment_defaults.base().require_annotations = Spanned::dummy(false).into();
     }
 
-    config
+    Ok(config)
 }
 
 fn get_host() -> &'static str {
@@ -181,7 +184,9 @@ fn file_filter(path: &Path, config: &ui_test::Config, cfg: MyConfig<'_>) -> Opti
     }
     let skip = match cfg.mode {
         Mode::Ui => false,
-        Mode::SolcSolidity => solc::solidity::should_skip(path).is_err(),
+        Mode::SolcSolidity | Mode::SolcSolidityTypeck => {
+            solc::solidity::should_skip(path).is_err()
+        }
         Mode::SolcYul => solc::yul::should_skip(path).is_err(),
     };
     Some(!skip)
@@ -213,18 +218,19 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
     let expected_errors = errors::Error::load_solc(src);
     let expected_error = expected_errors.iter().find(|e| e.is_error());
     let code = if let Some(expected_error) = expected_error {
-        // Expect failure only for parser errors, otherwise ignore exit code.
-        if expected_error.solc_kind.is_some_and(|kind| kind.is_parser_error()) {
-            Some(1)
-        } else {
-            None
+        match cfg.mode {
+            // The typeck corpus mode uses solc's expected semantic errors as the oracle.
+            Mode::SolcSolidityTypeck => Some(1),
+            // The parser corpus mode only has a parser oracle, so ignore later semantic failures.
+            _ if expected_error.solc_kind.is_some_and(|kind| kind.is_parser_error()) => Some(1),
+            _ => None,
         }
     } else {
         Some(0)
     };
     config.comment_defaults.base().exit_status = code.map(Spanned::dummy).into();
 
-    if matches!(cfg.mode, Mode::SolcSolidity) {
+    if matches!(cfg.mode, Mode::SolcSolidity | Mode::SolcSolidityTypeck) {
         let flags = &mut config.comment_defaults.base().compile_flags;
         let has_delimiters = solc::solidity::handle_delimiters(src, path, cfg.tmp_dir, |arg| {
             flags.push(arg.into_string().unwrap())
@@ -240,6 +246,7 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
 enum Mode {
     Ui,
     SolcSolidity,
+    SolcSolidityTypeck,
     SolcYul,
 }
 
@@ -248,6 +255,7 @@ impl Mode {
         Some(match s {
             "ui" => Self::Ui,
             "solc-solidity" => Self::SolcSolidity,
+            "solc-solidity-typeck" => Self::SolcSolidityTypeck,
             "solc-yul" => Self::SolcYul,
             _ => return None,
         })
@@ -257,16 +265,17 @@ impl Mode {
         match self {
             Self::Ui => "ui",
             Self::SolcSolidity => "solc-solidity",
+            Self::SolcSolidityTypeck => "solc-solidity-typeck",
             Self::SolcYul => "solc-yul",
         }
     }
 
     fn is_solc(self) -> bool {
-        matches!(self, Self::SolcSolidity | Self::SolcYul)
+        matches!(self, Self::SolcSolidity | Self::SolcSolidityTypeck | Self::SolcYul)
     }
 
     fn allows_yul(self) -> bool {
-        !matches!(self, Self::SolcSolidity)
+        !matches!(self, Self::SolcSolidity | Self::SolcSolidityTypeck)
     }
 }
 

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -184,9 +184,7 @@ fn file_filter(path: &Path, config: &ui_test::Config, cfg: MyConfig<'_>) -> Opti
     }
     let skip = match cfg.mode {
         Mode::Ui => false,
-        Mode::SolcSolidity | Mode::SolcSolidityTypeck => {
-            solc::solidity::should_skip(path).is_err()
-        }
+        Mode::SolcSolidity | Mode::SolcSolidityTypeck => solc::solidity::should_skip(path).is_err(),
         Mode::SolcYul => solc::yul::should_skip(path).is_err(),
     };
     Some(!skip)


### PR DESCRIPTION
## Summary
1 files changed (+29 -20). Touches `tools/tester/src/lib.rs`. Diff size: +29/-20. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo check -p solar-tester exit 0 required; cargo test -p solar-tester exit 0 required; bash -c "grep -R \"solc-solidity-typeck\" tools/tester crates/solar >/dev/null" exit 0 required. Risk flags: Typeck corpus currently has many expected failures; oracle wrapper only asserts no nextest infrastructure exit 101.; Missing solc executable handling is unchanged because this tester path invokes Solar, not solc.. Advisory oracles deferred to CI/reviewer follow-up (24 total): `cargo.fmt`, `typos`, `cargo.check`, .... Run evidence: run_rs_Bd0puGzewU on arjunblj/solar.

## Design Rationale
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Validation
- cargo.fmt [advisory/deferred] command=`cargo +nightly fmt --all --check` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- typos [advisory/deferred] command=`typos --format brief` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.check [advisory/deferred] command=`cargo check --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.build [advisory/deferred] command=`cargo build --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.clippy [advisory/deferred] command=`cargo clippy --workspace --all-targets -- -D warnings` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.nextest [advisory/deferred] command=`cargo nextest run --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.doctest [advisory/deferred] command=`cargo test --doc --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.uitest [advisory/deferred] command=`cargo uitest` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- snapshots.clean [advisory/deferred] command=`git diff --exit-code -- ':(glob)tests/ui/**/*.stderr' ':(glob)tests/ui/**/*.stdout' ':(glob)**/*.snap'` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.syntax [advisory/deferred] command=`TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.yul [advisory/deferred] command=`TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.standard_json.frontend [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- foundry.config [advisory/deferred] command=`cd $PADS_FOUNDRY_PROJECT && test -f foundry.toml && forge config --json && forge remappings` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- foundry.standard_json [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- mir.roundtrip [advisory/deferred] command=`cargo test -p solar-mir` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.bytecode [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- runtime.equivalence [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- fuzz.differential [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- fuzz.regression-minimized [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- perf.phase-report [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- coverage.report [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- perf.codspeed [advisory/deferred] command=`cargo codspeed build && cargo codspeed run` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- perf.iai [advisory/deferred] command=`cargo bench -p solar-bench --bench iai` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- research.artifact [advisory/deferred] command=`test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- Runtime evidence is available in Pads for maintainers with access.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

---
Prepared by the pads.dev autonomous orchestrator. A human owns every decision.
- Live trace: https://pads.paradigm-36f.workers.dev/research/rs_Bd0puGzewU/trace