### PR TITLE
Emit baseline ledger hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /*.sol
 /*.yul
 /tmp
+.pads-artifacts/baseline.json
 .DS_Store


### PR DESCRIPTION
## Summary
1 files changed (+1 -0). Touches `.gitignore`. Diff size: +1/-0. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: python3 scripts/pads/baseline-ledger.py && python3 -m py_compile scripts/pads/baseline-ledger.py exit 0 required; cargo check -p solar-tester exit 0 required; python3 JSON assertion for ingested_sha/tool_versions/corpus_counts/skip_counts/elapsed/gate_class exit 0 advisory. Risk flags: The hook mirrors current tester skip predicates in Python, so future Rust skip-list changes should update the ledger hook too.; Required jq oracle could not run locally because jq is not installed; equivalent Python JSON assertion passed.. Advisory oracles deferred to CI/reviewer follow-up (17 total): `lint`, `test`, `verification:cargo +nightly fmt --all --check`, .... Run evidence: run_rs_97eGP9ccuG on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- 17 advisory oracles deferred to CI; see Solar's required checks before marking the draft ready.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 1 files changed
- +1 / -0