### PR TITLE
Register `solc-solidity-typeck` mode

### DIFF
--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -66,7 +66,7 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
 
     let path = match mode {
         Mode::Ui => "tests/ui/",
-        Mode::SolcSolidity => "testdata/solidity/test/",
+        Mode::SolcSolidity | Mode::SolcSolidityTypeck => "testdata/solidity/test/",
         Mode::SolcYul => "testdata/solidity/test/libyul/",
     };
     let tests_root = root.join(path);
@@ -86,8 +86,11 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
             args: {
                 let mut args =
                     vec!["-j1", "--error-format=rustc-json", "-Zui-testing", "-Zparse-yul"];
-                if mode.is_solc() {
+                if matches!(mode, Mode::SolcSolidity | Mode::SolcYul) {
                     args.push("--stop-after=parsing");
+                }
+                if matches!(mode, Mode::SolcSolidityTypeck) {
+                    args.push("-Ztypeck");
                 }
                 args.into_iter().map(Into::into).collect()
             },
@@ -182,6 +185,7 @@ fn file_filter(path: &Path, config: &ui_test::Config, cfg: MyConfig<'_>) -> Opti
     let skip = match cfg.mode {
         Mode::Ui => false,
         Mode::SolcSolidity => solc::solidity::should_skip(path).is_err(),
+        Mode::SolcSolidityTypeck => solc::solidity::should_skip_typeck(path).is_err(),
         Mode::SolcYul => solc::yul::should_skip(path).is_err(),
     };
     Some(!skip)
@@ -213,8 +217,11 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
     let expected_errors = errors::Error::load_solc(src);
     let expected_error = expected_errors.iter().find(|e| e.is_error());
     let code = if let Some(expected_error) = expected_error {
-        // Expect failure only for parser errors, otherwise ignore exit code.
-        if expected_error.solc_kind.is_some_and(|kind| kind.is_parser_error()) {
+        if matches!(cfg.mode, Mode::SolcSolidityTypeck) {
+            // The typeck lane is a real exit-code oracle: any solc error must make Solar fail.
+            Some(1)
+        } else if expected_error.solc_kind.is_some_and(|kind| kind.is_parser_error()) {
+            // The parser lane stops before typechecking, so only parser errors are observable.
             Some(1)
         } else {
             None
@@ -224,7 +231,7 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
     };
     config.comment_defaults.base().exit_status = code.map(Spanned::dummy).into();
 
-    if matches!(cfg.mode, Mode::SolcSolidity) {
+    if matches!(cfg.mode, Mode::SolcSolidity | Mode::SolcSolidityTypeck) {
         let flags = &mut config.comment_defaults.base().compile_flags;
         let has_delimiters = solc::solidity::handle_delimiters(src, path, cfg.tmp_dir, |arg| {
             flags.push(arg.into_string().unwrap())
@@ -240,6 +247,7 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
 enum Mode {
     Ui,
     SolcSolidity,
+    SolcSolidityTypeck,
     SolcYul,
 }
 
@@ -248,6 +256,7 @@ impl Mode {
         Some(match s {
             "ui" => Self::Ui,
             "solc-solidity" => Self::SolcSolidity,
+            "solc-solidity-typeck" => Self::SolcSolidityTypeck,
             "solc-yul" => Self::SolcYul,
             _ => return None,
         })
@@ -257,16 +266,17 @@ impl Mode {
         match self {
             Self::Ui => "ui",
             Self::SolcSolidity => "solc-solidity",
+            Self::SolcSolidityTypeck => "solc-solidity-typeck",
             Self::SolcYul => "solc-yul",
         }
     }
 
     fn is_solc(self) -> bool {
-        matches!(self, Self::SolcSolidity | Self::SolcYul)
+        matches!(self, Self::SolcSolidity | Self::SolcSolidityTypeck | Self::SolcYul)
     }
 
     fn allows_yul(self) -> bool {
-        !matches!(self, Self::SolcSolidity)
+        !matches!(self, Self::SolcSolidity | Self::SolcSolidityTypeck)
     }
 }
 

--- a/tools/tester/src/solc/solidity.rs
+++ b/tools/tester/src/solc/solidity.rs
@@ -112,6 +112,17 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
     Ok(())
 }
 
+pub(crate) fn should_skip_typeck(path: &Path) -> Result<(), &'static str> {
+    should_skip(path)?;
+
+    let path_contains = path_contains_curry(path);
+    if !path_contains("/nameAndTypeResolution/") && !path_contains("/types/") {
+        return Err("not part of the initial typeck corpus slice");
+    }
+
+    Ok(())
+}
+
 /// Handles `====` delimiters in a solc test file, and creates temporary files as necessary.
 ///
 /// Returns `true` if it contains delimiters and the caller should not compile the original file.


### PR DESCRIPTION
## Summary
2 files changed (+28 -7). Touches `tools/tester/src/lib.rs`, `tools/tester/src/solc/solidity.rs`. Diff size: +28/-7. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo check -p solar-tester exit 0 required; TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests exit 0 required; TESTER_MODE=solc-solidity-typeck cargo nextest run -p solar-compiler --test tests exit 100 required. Risk flags: Typeck corpus oracle currently fails because it exposes existing Solar typechecker gaps.; The initial typeck slice is broad (`nameAndTypeResolution` and `types`) and may need planned xfail accounting later.. Advisory oracles deferred to CI/reviewer follow-up (17 total): `lint`, `test`, `verification:cargo +nightly fmt --all --check`, .... Run evidence: run_rs_7C6KSni4YS on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- 17 advisory oracles deferred to CI; see Solar's required checks before marking the draft ready.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 2 files changed
- +28 / -7