### PR TITLE
Wire `--standard-json` stdin handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,6 +3008,7 @@ dependencies = [
  "clap",
  "libc",
  "mimalloc",
+ "serde_json",
  "solar-config",
  "solar-interface",
  "solar-sema",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,7 @@ solar-sema.workspace = true
 alloy-primitives.workspace = true
 cfg-if.workspace = true
 clap = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 
 tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true, features = [

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -8,7 +8,10 @@
 use clap::Parser as _;
 use solar_interface::{Result, Session};
 use solar_sema::CompilerRef;
-use std::ops::ControlFlow;
+use std::{
+    io::{self, Read, Write},
+    ops::ControlFlow,
+};
 
 pub use solar_config::{self as config, Opts, UnstableOpts, version};
 
@@ -45,7 +48,135 @@ where
 }
 
 pub fn run_compiler_args(opts: Opts) -> Result {
+    if opts.standard_json {
+        return run_standard_json(opts);
+    }
+
     run_compiler_with(opts, run_default)
+}
+
+fn run_standard_json(opts: Opts) -> Result {
+    let mut input = String::new();
+    let mut stdin = io::stdin();
+    if let Err(error) = stdin.read_to_string(&mut input) {
+        write_standard_json_output(
+            opts.pretty_json,
+            vec![standard_json_error("IOError", format!("failed to read stdin: {error}"))],
+        );
+        return Ok(());
+    }
+
+    let input = match serde_json::from_str::<serde_json::Value>(&input) {
+        Ok(input) => input,
+        Err(error) => {
+            write_standard_json_output(
+                opts.pretty_json,
+                vec![standard_json_error("JSONError", format!("invalid JSON input: {error}"))],
+            );
+            return Ok(());
+        }
+    };
+
+    let errors = validate_standard_json_input(&input);
+    write_standard_json_output(opts.pretty_json, errors);
+    Ok(())
+}
+
+fn validate_standard_json_input(input: &serde_json::Value) -> Vec<serde_json::Value> {
+    let mut errors = Vec::new();
+
+    let Some(input) = input.as_object() else {
+        errors.push(standard_json_error("JSONError", "standard JSON input must be an object"));
+        return errors;
+    };
+
+    match input.get("language") {
+        Some(language) if language == "Solidity" => {}
+        Some(language) if language.is_string() => errors.push(standard_json_error(
+            "JSONError",
+            "unsupported language: only Solidity is currently supported",
+        )),
+        Some(_) => errors.push(standard_json_error("JSONError", "language must be a string")),
+        None => errors.push(standard_json_error("JSONError", "missing required field: language")),
+    }
+
+    match input.get("sources").and_then(serde_json::Value::as_object) {
+        Some(sources) => {
+            for (name, source) in sources {
+                let Some(source) = source.as_object() else {
+                    errors.push(standard_json_error(
+                        "JSONError",
+                        format!("source {name:?} must be an object"),
+                    ));
+                    continue;
+                };
+
+                if source.contains_key("urls") {
+                    errors.push(standard_json_error(
+                        "JSONError",
+                        format!(
+                            "source {name:?} uses unsupported urls; inline content is required"
+                        ),
+                    ));
+                }
+
+                match source.get("content") {
+                    Some(content) if content.is_string() => {}
+                    Some(_) => errors.push(standard_json_error(
+                        "JSONError",
+                        format!("source {name:?} content must be a string"),
+                    )),
+                    None => errors.push(standard_json_error(
+                        "JSONError",
+                        format!("source {name:?} is missing inline content"),
+                    )),
+                }
+            }
+        }
+        None => errors.push(standard_json_error("JSONError", "missing required field: sources")),
+    }
+
+    if let Some(settings) = input.get("settings") {
+        match settings.as_object() {
+            Some(settings) => {
+                for setting in settings.keys() {
+                    errors.push(standard_json_error(
+                        "JSONError",
+                        format!("unsupported settings field: settings.{setting}"),
+                    ));
+                }
+            }
+            None => errors.push(standard_json_error("JSONError", "settings must be an object")),
+        }
+    }
+
+    errors
+}
+
+fn standard_json_error(error_type: &'static str, message: impl Into<String>) -> serde_json::Value {
+    let message = message.into();
+    serde_json::json!({
+        "component": "general",
+        "errorCode": "0",
+        "formattedMessage": message,
+        "message": message,
+        "severity": "error",
+        "type": error_type,
+    })
+}
+
+fn write_standard_json_output(pretty: bool, errors: Vec<serde_json::Value>) {
+    let output = serde_json::json!({ "errors": errors });
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    let result = if pretty {
+        serde_json::to_writer_pretty(&mut stdout, &output)
+    } else {
+        serde_json::to_writer(&mut stdout, &output)
+    };
+    if result.is_ok() {
+        let _ = writeln!(stdout);
+    }
 }
 
 fn run_default(compiler: &mut CompilerRef<'_>) -> Result {

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -82,6 +82,9 @@ pub struct Opts {
         arg(help_heading = "Input options", long, value_enum, default_value_t, hide = true)
     )]
     pub language: Language,
+    /// Read compiler input from stdin as Solidity Standard JSON.
+    #[cfg_attr(feature = "clap", arg(help_heading = "Input options", long, hide = true))]
+    pub standard_json: bool,
 
     /// Number of threads to use. Zero specifies the number of logical cores.
     #[cfg_attr(feature = "clap", arg(long, short = 'j', visible_alias = "jobs", default_value_t))]


### PR DESCRIPTION
## Summary
4 files changed (+137 -1). Touches `Cargo.lock`, `crates/cli/Cargo.toml`, `crates/cli/src/lib.rs`, `crates/config/src/opts.rs`. Diff size: +137/-1. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo check -p solar-cli exit 0 required; cargo +nightly fmt --all --check exit 0 required; printf '%s' '{"language":"Solidity","sources":{"A.sol":{"content":"contract A{}"}}}' | cargo run -- --standard-json | python3 -m json.tool >/dev/null; printf '%s' '{bad json' | cargo run -- --standard-json | python3 -m json.tool >/dev/null; cargo clippy --workspace --all-targets; cargo test exit 0 required. Risk flags: This is an infrastructure-only Standard JSON front door; full solc-compatible contracts/sources artifact emission is not implemented here.; The flag is hidden to avoid changing existing help UI snapshots while wiring the initial stdin mode.. Advisory oracles deferred to CI/reviewer follow-up (17 total): `lint`, `test`, `verification:cargo +nightly fmt --all --check`, .... Run evidence: run_rs_7C6KSni4YS on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- 17 advisory oracles deferred to CI; see Solar's required checks before marking the draft ready.

## Follow-ups
- Review reward-hack lint warning before merge: touches_readonly:Cargo.lock
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 4 files changed
- +137 / -1