### PR TITLE
Shape standard-json errors

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -136,18 +136,10 @@ fn validate_standard_json_input(input: &serde_json::Value) -> Vec<serde_json::Va
         None => errors.push(standard_json_error("JSONError", "missing required field: sources")),
     }
 
-    if let Some(settings) = input.get("settings") {
-        match settings.as_object() {
-            Some(settings) => {
-                for setting in settings.keys() {
-                    errors.push(standard_json_error(
-                        "JSONError",
-                        format!("unsupported settings field: settings.{setting}"),
-                    ));
-                }
-            }
-            None => errors.push(standard_json_error("JSONError", "settings must be an object")),
-        }
+    if let Some(settings) = input.get("settings")
+        && !settings.is_object()
+    {
+        errors.push(standard_json_error("JSONError", "settings must be an object"));
     }
 
     errors


### PR DESCRIPTION
## Summary
1 files changed (+4 -12). Touches `crates/cli/src/lib.rs`. Diff size: +4/-12. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo check -p solar-cli -p solar-compiler exit 0 required; cargo +nightly fmt --all --check exit 0 required; cargo run -q -p solar-compiler -- --standard-json < scripts/standard_json_template.json >/tmp/solar-stdjson.json && python3 -m json.tool /tmp/solar-stdjson.json >/dev/null && cat /tmp/solar-stdjson.json exit 0 required. Risk flags: Partial slice only; compiler diagnostics are not yet captured into standard-json errors.; selectedOutputs/artifact parity remains unsupported.. Advisory oracles deferred to CI/reviewer follow-up (17 total): `lint`, `test`, `verification:cargo +nightly fmt --all --check`, .... Run evidence: run_rs_euXW9EcIiM on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- 17 advisory oracles deferred to CI; see Solar's required checks before marking the draft ready.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 1 files changed
- +4 / -12