### PR TITLE
Emit versioned corpus counts

### DIFF
--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -426,6 +426,10 @@ impl BaselineTool {
 
 struct BaselineMode {
     name: &'static str,
+    tester_mode: &'static str,
+    corpus_id: String,
+    solc_version: String,
+    solc_version_source: &'static str,
     corpus_root: String,
     command: Vec<String>,
     counts: BaselineCounts,
@@ -441,6 +445,10 @@ impl BaselineMode {
 
         Self {
             name: mode.to_str(),
+            tester_mode: mode.to_str(),
+            corpus_id: corpus_id(&config.root_dir, mode),
+            solc_version: solc_version_or_unknown(),
+            solc_version_source: solc_version_source(),
             corpus_root: display_path(&config.root_dir),
             command,
             counts: BaselineCounts::scan(&config.root_dir, mode),
@@ -467,6 +475,22 @@ impl BaselineMode {
         write_json_string(json, self.name);
         json.push_str(",\n");
         json.push_str(&field_indent);
+        json.push_str("\"tester_mode\": ");
+        write_json_string(json, self.tester_mode);
+        json.push_str(",\n");
+        json.push_str(&field_indent);
+        json.push_str("\"corpus_id\": ");
+        write_json_string(json, &self.corpus_id);
+        json.push_str(",\n");
+        json.push_str(&field_indent);
+        json.push_str("\"solc_version\": ");
+        write_json_string(json, &self.solc_version);
+        json.push_str(",\n");
+        json.push_str(&field_indent);
+        json.push_str("\"solc_version_source\": ");
+        write_json_string(json, self.solc_version_source);
+        json.push_str(",\n");
+        json.push_str(&field_indent);
         json.push_str("\"corpus_root\": ");
         write_json_string(json, &self.corpus_root);
         json.push_str(",\n");
@@ -486,6 +510,32 @@ impl BaselineMode {
         json.push_str(indent);
         json.push('}');
     }
+}
+
+fn corpus_id(root: &Path, mode: Mode) -> String {
+    root.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| mode.to_str())
+        .to_owned()
+}
+
+fn solc_version_or_unknown() -> String {
+    let solc = std::env::var_os("SOLC")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("solc"));
+
+    std::process::Command::new(solc)
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|output| first_output_line(&output))
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+fn solc_version_source() -> &'static str {
+    "solc --version"
 }
 
 #[derive(Default)]
@@ -517,6 +567,7 @@ impl BaselineCounts {
     fn write_json(&self, json: &mut String) {
         json.push_str("{\"total\": ");
         let _ = write!(json, "{}", self.total);
+        let _ = write!(json, ", \"runnable\": {}", self.runnable);
         json.push_str(", \"pass\": ");
         write_json_opt_u64(json, self.pass);
         json.push_str(", \"fail\": ");


### PR DESCRIPTION
## Summary
1 files changed (+51 -0). Touches `tools/tester/src/lib.rs`. Diff size: +51/-0. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo check -p solar-tester exit 0 required; cargo +nightly fmt --all --check exit 0 required. Risk flags: solc_version_source is static; solc_version value is unknown if --version is unavailable or unparsable.; Full solc-solidity/solc-yul nextest oracles were not run here.. Advisory oracles deferred to CI/reviewer follow-up (24 total): `cargo.fmt`, `typos`, `cargo.check`, .... Run evidence: run_rs_479LAysUnW on arjunblj/solar.

## Design Rationale
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Validation
- cargo.fmt [advisory/deferred] command=`cargo +nightly fmt --all --check` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- typos [advisory/deferred] command=`typos --format brief` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.check [advisory/deferred] command=`cargo check --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.build [advisory/deferred] command=`cargo build --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.clippy [advisory/deferred] command=`cargo clippy --workspace --all-targets -- -D warnings` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.nextest [advisory/deferred] command=`cargo nextest run --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.doctest [advisory/deferred] command=`cargo test --doc --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.uitest [advisory/deferred] command=`cargo uitest` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- snapshots.clean [advisory/deferred] command=`git diff --exit-code -- ':(glob)tests/ui/**/*.stderr' ':(glob)tests/ui/**/*.stdout' ':(glob)**/*.snap'` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.syntax [advisory/deferred] command=`TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.yul [advisory/deferred] command=`TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.standard_json.frontend [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- foundry.config [advisory/deferred] command=`cd $PADS_FOUNDRY_PROJECT && test -f foundry.toml && forge config --json && forge remappings` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- foundry.standard_json [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- mir.roundtrip [advisory/deferred] command=`cargo test -p solar-mir` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.bytecode [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- runtime.equivalence [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- fuzz.differential [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- fuzz.regression-minimized [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- perf.phase-report [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- coverage.report [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- perf.codspeed [advisory/deferred] command=`cargo codspeed build && cargo codspeed run` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- perf.iai [advisory/deferred] command=`cargo bench -p solar-bench --bench iai` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- research.artifact [advisory/deferred] command=`test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- Runtime evidence is available in Pads for maintainers with access.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

---
Prepared by the pads.dev autonomous orchestrator. A human owns every decision.
- Live trace: https://pads.paradigm-36f.workers.dev/research/rs_479LAysUnW/trace