### PR TITLE
Thread diagnostic fields through

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -155,10 +155,14 @@ fn validate_standard_json_input(input: &serde_json::Value) -> Vec<serde_json::Va
 
 fn standard_json_error(error_type: &'static str, message: impl Into<String>) -> serde_json::Value {
     let message = message.into();
+    let formatted_message = format!("{error_type}: {message}");
     serde_json::json!({
         "component": "general",
+        // Standard JSON requires a stable diagnostic code field. These
+        // front-door validation diagnostics are Solar-specific and have no
+        // solc numeric code yet, so keep using the documented sentinel.
         "errorCode": "0",
-        "formattedMessage": message,
+        "formattedMessage": formatted_message,
         "message": message,
         "severity": "error",
         "type": error_type,


### PR DESCRIPTION
## Summary
1 files changed (+5 -1). Touches `crates/cli/src/lib.rs`. Diff size: +5/-1. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo check -p solar-compiler exit 0 required; cargo +nightly fmt --all --check exit 0 required; cargo test -p solar-compiler standard_json -- --nocapture exit 0 required. Risk flags: No new fixture assertion was added for errorCode sentinel before submission.; Change affects front-door validation errors, not full compiler diagnostic conversion.. Advisory oracles deferred to CI/reviewer follow-up (24 total): `cargo.fmt`, `typos`, `cargo.check`, .... Run evidence: run_rs_479LAysUnW on arjunblj/solar.

## Design Rationale
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Validation
- cargo.fmt [advisory/deferred] command=`cargo +nightly fmt --all --check` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- typos [advisory/deferred] command=`typos --format brief` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.check [advisory/deferred] command=`cargo check --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.build [advisory/deferred] command=`cargo build --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.clippy [advisory/deferred] command=`cargo clippy --workspace --all-targets -- -D warnings` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.nextest [advisory/deferred] command=`cargo nextest run --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.doctest [advisory/deferred] command=`cargo test --doc --workspace` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- cargo.uitest [advisory/deferred] command=`cargo uitest` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- snapshots.clean [advisory/deferred] command=`git diff --exit-code -- ':(glob)tests/ui/**/*.stderr' ':(glob)tests/ui/**/*.stdout' ':(glob)**/*.snap'` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.syntax [advisory/deferred] command=`TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.yul [advisory/deferred] command=`TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.standard_json.frontend [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- foundry.config [advisory/deferred] command=`cd $PADS_FOUNDRY_PROJECT && test -f foundry.toml && forge config --json && forge remappings` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- foundry.standard_json [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- mir.roundtrip [advisory/deferred] command=`cargo test -p solar-mir` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- solc.bytecode [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- runtime.equivalence [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- fuzz.differential [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- fuzz.regression-minimized [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- perf.phase-report [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- coverage.report [advisory/deferred] command=`cargo +nightly fmt --all --check && typos --format brief && cargo check --workspace && cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace && cargo test --doc --workspace && cargo uitest && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-yul cargo nextest run -p solar-compiler --test tests && TESTER_MODE=solc-solidity cargo nextest run -p solar-compiler --test tests && forge config --json && forge remappings && cargo test -p solar-mir && cargo codspeed build && cargo codspeed run && cargo bench -p solar-bench --bench iai && test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- perf.codspeed [advisory/deferred] command=`cargo codspeed build && cargo codspeed run` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- perf.iai [advisory/deferred] command=`cargo bench -p solar-bench --bench iai` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- research.artifact [advisory/deferred] command=`test -d research || true` (delta: not reported) — Deferred advisory oracle for sandboxless draft PR publication.
- Runtime evidence is available in Pads for maintainers with access.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

---
Prepared by the pads.dev autonomous orchestrator. A human owns every decision.
- Live trace: https://pads.paradigm-36f.workers.dev/research/rs_479LAysUnW/trace