### PR TITLE
Wire unsupported outputSelection errors

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -139,11 +139,17 @@ fn validate_standard_json_input(input: &serde_json::Value) -> Vec<serde_json::Va
     if let Some(settings) = input.get("settings") {
         match settings.as_object() {
             Some(settings) => {
-                for setting in settings.keys() {
-                    errors.push(standard_json_error(
-                        "JSONError",
-                        format!("unsupported settings field: settings.{setting}"),
-                    ));
+                for (setting, value) in settings {
+                    match setting.as_str() {
+                        "evmVersion" | "libraries" | "metadata" | "optimizer" => {}
+                        "outputSelection" => {
+                            validate_standard_json_output_selection(value, &mut errors)
+                        }
+                        _ => errors.push(standard_json_error(
+                            "JSONError",
+                            format!("unsupported settings field: settings.{setting}"),
+                        )),
+                    }
                 }
             }
             None => errors.push(standard_json_error("JSONError", "settings must be an object")),
@@ -151,6 +157,63 @@ fn validate_standard_json_input(input: &serde_json::Value) -> Vec<serde_json::Va
     }
 
     errors
+}
+
+fn validate_standard_json_output_selection(
+    output_selection: &serde_json::Value,
+    errors: &mut Vec<serde_json::Value>,
+) {
+    let Some(source_selectors) = output_selection.as_object() else {
+        errors.push(standard_json_error("JSONError", "settings.outputSelection must be an object"));
+        return;
+    };
+
+    for (source_selector, contract_selectors) in source_selectors {
+        let Some(contract_selectors) = contract_selectors.as_object() else {
+            errors.push(standard_json_error(
+                "JSONError",
+                format!("settings.outputSelection[{source_selector:?}] must be an object"),
+            ));
+            continue;
+        };
+
+        for (contract_selector, outputs) in contract_selectors {
+            let Some(outputs) = outputs.as_array() else {
+                errors.push(standard_json_error(
+                    "JSONError",
+                    format!(
+                        "settings.outputSelection[{source_selector:?}][{contract_selector:?}] must be an array"
+                    ),
+                ));
+                continue;
+            };
+
+            for output in outputs {
+                let Some(output) = output.as_str() else {
+                    errors.push(standard_json_error(
+                        "JSONError",
+                        format!(
+                            "settings.outputSelection[{source_selector:?}][{contract_selector:?}] entries must be strings"
+                        ),
+                    ));
+                    continue;
+                };
+
+                if !is_supported_standard_json_output(output) {
+                    errors.push(standard_json_error(
+                        "JSONError",
+                        format!(
+                            "unsupported outputSelection entry: settings.outputSelection[{source_selector:?}][{contract_selector:?}] contains {output:?}"
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+fn is_supported_standard_json_output(output: &str) -> bool {
+    matches!(output, "abi" | "evm.methodIdentifiers")
 }
 
 fn standard_json_error(error_type: &'static str, message: impl Into<String>) -> serde_json::Value {


### PR DESCRIPTION
## Summary
1 files changed (+67 -4). Touches `crates/cli/src/lib.rs`. Diff size: +67/-4. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo check -p solar-compiler exit 0 required; cargo test -p solar-compiler exit 0 required; cargo +nightly fmt --all --check exit 0 required. Risk flags: Supported outputSelection allowlist is intentionally narrow: abi and evm.methodIdentifiers only.; Standard JSON output remains validation-only in this patch; artifacts are not generated here.. Advisory oracles deferred to CI/reviewer follow-up (17 total): `lint`, `test`, `verification:cargo +nightly fmt --all --check`, .... Run evidence: run_rs_UxYblxzP4x on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- 17 advisory oracles deferred to CI; see Solar's required checks before marking the draft ready.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 1 files changed
- +67 / -4