### PR TITLE
Replace diagnostic unimplemented arms

### DIFF
--- a/crates/interface/src/diagnostics/context.rs
+++ b/crates/interface/src/diagnostics/context.rs
@@ -191,7 +191,14 @@ impl DiagCtxt {
                     .terminal_width(opts.diagnostic_width);
                 Box::new(json)
             }
-            format => unimplemented!("{format:?}"),
+            _format => {
+                let human = HumanEmitter::stderr(opts.color)
+                    .source_map(Some(source_map))
+                    .ui_testing(opts.unstable.ui_testing)
+                    .human_kind(opts.error_format_human)
+                    .terminal_width(opts.diagnostic_width);
+                Box::new(human)
+            }
         };
         Self::new(emitter).with_flags(|flags| flags.update_from_opts(opts))
     }
@@ -580,5 +587,21 @@ impl DiagCtxtInner {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn json_error_format_falls_back_instead_of_panicking_without_json_feature() {
+        let opts = Opts { error_format: ErrorFormat::Json, ..Opts::default() };
+        let dcx = DiagCtxt::from_opts(&opts);
+
+        let _guarantee = dcx.err("json diagnostics are fallback-rendered").emit();
+
+        assert_eq!(dcx.err_count(), 1);
     }
 }

--- a/crates/interface/src/diagnostics/emitter/human.rs
+++ b/crates/interface/src/diagnostics/emitter/human.rs
@@ -162,7 +162,9 @@ impl HumanEmitter {
             HumanEmitterKind::Short => {
                 self.renderer = self.renderer.short_message(true);
             }
-            _ => unimplemented!("{kind:?}"),
+            _ => {
+                self.renderer = self.renderer.decor_style(DecorStyle::Unicode);
+            }
         }
         self
     }


### PR DESCRIPTION
## Summary
2 files changed (+27 -2). Touches `crates/interface/src/diagnostics/context.rs`, `crates/interface/src/diagnostics/emitter/human.rs`. Diff size: +27/-2. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: bash -lc '! grep -R "unimplemented!" crates/interface/src/diagnostics' exit 0 required; cargo test -p solar-interface exit 0 required; cargo check -p solar-interface; cargo +nightly fmt --all --check exit 0 required. Risk flags: When built without json feature, JSON error format intentionally falls back to human output.; Unknown future HumanEmitterKind variants fall back to Unicode rendering.. Advisory oracles deferred to CI/reviewer follow-up (17 total): `lint`, `test`, `verification:cargo +nightly fmt --all --check`, .... Run evidence: run_rs_Zl5hUrEVxy on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- 17 advisory oracles deferred to CI; see Solar's required checks before marking the draft ready.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 2 files changed
- +27 / -2