### PR TITLE
Wire view-pure checker hook

### DIFF
--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -17,6 +17,7 @@ use std::ops::ControlFlow;
 mod checker;
 mod override_checker;
 mod udvt;
+mod view_pure;
 
 pub(crate) fn check(gcx: Gcx<'_>) {
     parallel!(
@@ -41,6 +42,7 @@ pub(crate) fn check(gcx: Gcx<'_>) {
             }
             if gcx.sess.opts.unstable.typeck {
                 // TODO: Parallelize more.
+                view_pure::check(gcx, id);
                 checker::check(gcx, id);
             }
         }),


### PR DESCRIPTION
## Summary
1 files changed (+2 -0). Touches `crates/sema/src/typeck/mod.rs`. Diff size: +2/-0. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: bash -c "test -f crates/sema/src/typeck/view_pure.rs" exit 0 required; cargo check -p solar-sema exit 0 required; cargo uitest exit 1 required. Risk flags: Full cargo uitest currently fails in CLI help snapshots unrelated to this typeck fixture.; Skeleton intentionally emits no view/pure diagnostics yet.. Advisory oracles deferred to CI/reviewer follow-up (17 total): `lint`, `test`, `verification:cargo +nightly fmt --all --check`, .... Run evidence: run_rs_uEH9IuRPaJ on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- 17 advisory oracles deferred to CI; see Solar's required checks before marking the draft ready.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 1 files changed
- +2 / -0