### PR TITLE
Wire outputSelection subset

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -9,6 +9,7 @@ use clap::Parser as _;
 use solar_interface::{Result, Session};
 use solar_sema::CompilerRef;
 use std::{
+    collections::BTreeSet,
     io::{self, Read, Write},
     ops::ControlFlow,
 };
@@ -140,10 +141,14 @@ fn validate_standard_json_input(input: &serde_json::Value) -> Vec<serde_json::Va
         match settings.as_object() {
             Some(settings) => {
                 for setting in settings.keys() {
-                    errors.push(standard_json_error(
-                        "JSONError",
-                        format!("unsupported settings field: settings.{setting}"),
-                    ));
+                    if setting == "outputSelection" {
+                        validate_standard_json_output_selection(input, &mut errors);
+                    } else {
+                        errors.push(standard_json_error(
+                            "JSONError",
+                            format!("unsupported settings field: settings.{setting}"),
+                        ));
+                    }
                 }
             }
             None => errors.push(standard_json_error("JSONError", "settings must be an object")),
@@ -151,6 +156,82 @@ fn validate_standard_json_input(input: &serde_json::Value) -> Vec<serde_json::Va
     }
 
     errors
+}
+
+fn validate_standard_json_output_selection(
+    input: &serde_json::Map<String, serde_json::Value>,
+    errors: &mut Vec<serde_json::Value>,
+) {
+    let Some(output_selection) = input
+        .get("settings")
+        .and_then(|settings| settings.get("outputSelection"))
+    else {
+        return;
+    };
+
+    let Some(output_selection) = output_selection.as_object() else {
+        errors.push(standard_json_error(
+            "JSONError",
+            "settings.outputSelection must be an object",
+        ));
+        return;
+    };
+
+    let source_names = input
+        .get("sources")
+        .and_then(serde_json::Value::as_object)
+        .map(|sources| sources.keys().map(String::as_str).collect::<BTreeSet<_>>())
+        .unwrap_or_default();
+
+    for (source_name, contracts) in output_selection {
+        if source_name != "*" && !source_names.contains(source_name.as_str()) {
+            errors.push(standard_json_error(
+                "JSONError",
+                format!("settings.outputSelection references unknown source {source_name:?}"),
+            ));
+        }
+
+        let Some(contracts) = contracts.as_object() else {
+            errors.push(standard_json_error(
+                "JSONError",
+                format!("settings.outputSelection[{source_name:?}] must be an object"),
+            ));
+            continue;
+        };
+
+        for (contract_name, outputs) in contracts {
+            let Some(outputs) = outputs.as_array() else {
+                errors.push(standard_json_error(
+                    "JSONError",
+                    format!(
+                        "settings.outputSelection[{source_name:?}][{contract_name:?}] must be an array"
+                    ),
+                ));
+                continue;
+            };
+
+            for output in outputs {
+                let Some(output) = output.as_str() else {
+                    errors.push(standard_json_error(
+                        "JSONError",
+                        format!(
+                            "settings.outputSelection[{source_name:?}][{contract_name:?}] entries must be strings"
+                        ),
+                    ));
+                    continue;
+                };
+
+                if !matches!(output, "abi" | "evm.methodIdentifiers") {
+                    errors.push(standard_json_error(
+                        "JSONError",
+                        format!(
+                            "unsupported standard JSON outputSelection entry {output:?}; supported outputs: abi, evm.methodIdentifiers"
+                        ),
+                    ));
+                }
+            }
+        }
+    }
 }
 
 fn standard_json_error(error_type: &'static str, message: impl Into<String>) -> serde_json::Value {


### PR DESCRIPTION
## Summary
1 files changed (+85 -4). Touches `crates/cli/src/lib.rs`. Diff size: +85/-4. No required draft gates were declared for this slice; rely on repo CI and linked run artifacts for first signal. Worker verification evidence: cargo check -p solar-compiler exit 0 required; cargo test -p solar-cli exit 0 required. Risk flags: Partial: validates subset but does not construct contracts output yet.; No UI fixture added due interaction budget after initial patch conflict.. Advisory oracles deferred to CI/reviewer follow-up (17 total): `lint`, `test`, `verification:cargo +nightly fmt --all --check`, .... Run evidence: run_rs_uEH9IuRPaJ on arjunblj/solar.

## Context
This PR was published from a stored, previously verified unified diff. Sandbox execution evidence is linked below; publication replay used GitHub base contents directly to avoid blocking review on sandbox acquisition.

## Testing
- 17 advisory oracles deferred to CI; see Solar's required checks before marking the draft ready.

## Follow-ups
- Re-run the relevant Solar oracle commands before marking this draft ready.

## Change footprint
- 1 files changed
- +85 / -4